### PR TITLE
Adding support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+rvm:
+  - 2.3
+
+addons:
+  apt:
+    sources:
+      - chef-stable-trusty
+    packages:
+      - chefdk
+
+before_script:
+  - cookstyle --version
+  - foodcritic --version
+
+script:
+  - cookstyle
+  - foodcritic .
+  - chef exec rspec
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/dbudwin/LEMPChefCookbook.svg?branch=master)](https://travis-ci.org/dbudwin/LEMPChefCookbook)
+
 # LEMPChefCookbook
 
 TODO: Enter the cookbook description here.

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,4 @@ version '0.1.0'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 issues_url 'https://github.com/dbudwin/LEMPChefCookbook/issues'
 source_url 'https://github.com/dbudwin/LEMPChefCookbook'
+supports 'ubuntu'


### PR DESCRIPTION
Runs `cookstyle`, `foodcritic`, and `rspec` tests.  `kitchen test` will need to run locally since VMs aren't supported on Travis CI.