### PR TITLE
Adding basic nginx recipe to cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,10 @@ verifier:
 
 platforms:
   - name: ubuntu-16.04
+    driver:
+      network:
+        - ["forwarded_port", { guest: 80, host: 8080 }]
+        - ["private_network", { ip: "192.168.33.33" }]
 
 suites:
   - name: default

--- a/attributes/nginx.rb
+++ b/attributes/nginx.rb
@@ -1,0 +1,1 @@
+default['nginx']['default_root'] = '/usr/share/nginx/html'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,5 @@ chef_version '>= 12.1' if respond_to?(:chef_version)
 issues_url 'https://github.com/dbudwin/LEMPChefCookbook/issues'
 source_url 'https://github.com/dbudwin/LEMPChefCookbook'
 supports 'ubuntu'
+
+depends 'chef_nginx', '~> 6.0.2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe 'LEMPChefCookbook::nginx'

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -1,5 +1,1 @@
-#
-# Cookbook:: LEMPChefCookbook
-# Recipe:: nginx
-#
-# Copyright:: 2017, The Authors, All Rights Reserved.
+include_recipe 'chef_nginx::default'

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -1,0 +1,5 @@
+#
+# Cookbook:: LEMPChefCookbook
+# Recipe:: nginx
+#
+# Copyright:: 2017, The Authors, All Rights Reserved.

--- a/spec/unit/recipes/nginx_spec.rb
+++ b/spec/unit/recipes/nginx_spec.rb
@@ -1,22 +1,18 @@
-#
-# Cookbook:: LEMPChefCookbook
-# Spec:: default
-#
-# Copyright:: 2017, The Authors, All Rights Reserved.
-
 require 'spec_helper'
 
 describe 'LEMPChefCookbook::nginx' do
   context 'When all attributes are default, on an Ubuntu 16.04' do
     let(:chef_run) do
-      # for a complete list of available platforms and versions see:
-      # https://github.com/customink/fauxhai/blob/master/PLATFORMS.md
       runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
       runner.converge(described_recipe)
     end
 
     it 'converges successfully' do
       expect { chef_run }.to_not raise_error
+    end
+
+    it 'nginx service is running' do
+      expect(chef_run).to start_service('nginx')
     end
   end
 end

--- a/spec/unit/recipes/nginx_spec.rb
+++ b/spec/unit/recipes/nginx_spec.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook:: LEMPChefCookbook
+# Spec:: default
+#
+# Copyright:: 2017, The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'LEMPChefCookbook::nginx' do
+  context 'When all attributes are default, on an Ubuntu 16.04' do
+    let(:chef_run) do
+      # for a complete list of available platforms and versions see:
+      # https://github.com/customink/fauxhai/blob/master/PLATFORMS.md
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -1,9 +1,0 @@
-unless os.windows?
-  describe user('root') do
-    it { should exist }
-  end
-end
-
-describe port(80) do
-  it { should_not be_listening }
-end

--- a/test/smoke/default/nginx_test.rb
+++ b/test/smoke/default/nginx_test.rb
@@ -1,0 +1,18 @@
+# # encoding: utf-8
+
+# Inspec test for recipe LEMPChefCookbook::nginx
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at http://inspec.io/docs/reference/resources/
+
+unless os.windows?
+  # This is an example test, replace with your own test.
+  describe user('root'), :skip do
+    it { should exist }
+  end
+end
+
+# This is an example test, replace it with your own test.
+describe port(80), :skip do
+  it { should_not be_listening }
+end

--- a/test/smoke/default/nginx_test.rb
+++ b/test/smoke/default/nginx_test.rb
@@ -1,18 +1,7 @@
-# # encoding: utf-8
-
-# Inspec test for recipe LEMPChefCookbook::nginx
-
-# The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
-
-unless os.windows?
-  # This is an example test, replace with your own test.
-  describe user('root'), :skip do
-    it { should exist }
-  end
+describe service('nginx') do
+  it { should be_running }
 end
 
-# This is an example test, replace it with your own test.
-describe port(80), :skip do
-  it { should_not be_listening }
+describe port(80) do
+  it { should be_listening }
 end


### PR DESCRIPTION
Created by running `chef generate recipe nginx`.  This recipe is just the default implementation and can be accessed using `kitchen converge` at `192.168.33.33` to serve the default nginx page.

![image](https://cloud.githubusercontent.com/assets/15161181/26765686/04a6f04c-494f-11e7-8ee9-8c4c5896c429.png)
