### PR TITLE
Setup PHP 7.0 with Fast CGI

### DIFF
--- a/attributes/php.rb
+++ b/attributes/php.rb
@@ -1,0 +1,4 @@
+default['php']['version'] = '7.0.15'
+default['php']['directives'] = {
+  'cgi.fix_pathinfo' => 0,
+}

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,4 +10,5 @@ issues_url 'https://github.com/dbudwin/LEMPChefCookbook/issues'
 source_url 'https://github.com/dbudwin/LEMPChefCookbook'
 supports 'ubuntu'
 
+depends 'php', '~> 4.2.0'
 depends 'chef_nginx', '~> 6.0.2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,1 +1,2 @@
+include_recipe 'LEMPChefCookbook::php'
 include_recipe 'LEMPChefCookbook::nginx'

--- a/recipes/php.rb
+++ b/recipes/php.rb
@@ -1,0 +1,17 @@
+include_recipe 'php::default'
+
+php_fpm_pool 'php-fpm' do
+  action :install
+end
+
+apt_package 'php-mysql' do
+  action :install
+end
+
+apt_package 'php-mbstring' do
+  action :install
+end
+
+service 'php7.0-fpm' do
+  action :restart
+end

--- a/spec/unit/recipes/php_spec.rb
+++ b/spec/unit/recipes/php_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'LEMPChefCookbook::php' do
+  context 'When all attributes are default, on an Ubuntu 16.04' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'restarts php7.0-fpm service' do
+      expect(chef_run).to restart_service('php7.0-fpm')
+    end
+  end
+end

--- a/test/smoke/default/php_test.rb
+++ b/test/smoke/default/php_test.rb
@@ -1,0 +1,20 @@
+describe service('php7.0-fpm') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe package('php7.0-fpm') do
+  it { should be_installed }
+end
+
+describe package('php-mysql') do
+  it { should be_installed }
+end
+
+describe package('php-mbstring') do
+  it { should be_installed }
+end
+
+describe command('php -v') do
+  its(:stdout) { should contain('PHP 7.0.15-0') }
+end


### PR DESCRIPTION
-Installed packages needed for running Laravel
-Fixes security hole in PHP (https://serverfault.com/questions/627903/is-the-php-option-cgi-fix-pathinfo-really-dangerous-with-nginx-php-fpm)